### PR TITLE
Add an update API to update the multiple entries in the store

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ Get a value by the give key.
 store.get('key');
 ```
 
+### update
+
+Update multiple entries of the store at once. While updating, you could accept the current state of the store as well.
+
+```js
+store.update(function(state) {
+  return {
+    newField: 10,
+    existingField: !Boolean(existingField)
+  };
+});
+```
+
 ### getAll
 
 Get all the key values pairs in the store as a map.

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,27 @@ export default class Podda {
     });
   }
 
-  set(key, value) {
+  set(arg1, arg2) {
+    if (typeof arg1 === 'function') {
+      return this._setFn(arg1);
+    }
+
+    return this._setItem(arg1, arg2);
+  }
+
+  _setFn(fn) {
+    const currentState = this.data.toJS();
+    const newFields = fn(currentState);
+    if (newFields === null || newFields === undefined) {
+      throw new Error('You must provide an object with updated values for Podda.set(fn)');
+    }
+
+    Object.keys(newFields).forEach((key) => {
+      this.set(key, newFields[key]);
+    });
+  }
+
+  _setItem(key, value) {
     this.data = this.data.set(key, Immutable.fromJS(value));
     this.callbacks.forEach((cb) => {
       cb(this.getAll());

--- a/src/index.js
+++ b/src/index.js
@@ -14,15 +14,16 @@ export default class Podda {
     });
   }
 
-  set(arg1, arg2) {
-    if (typeof arg1 === 'function') {
-      return this._setFn(arg1);
-    }
+  set(key, value) {
+    this.data = this.data.set(key, Immutable.fromJS(value));
+    this.callbacks.forEach((cb) => {
+      cb(this.getAll());
+    });
 
-    return this._setItem(arg1, arg2);
+    this.fire(key, value);
   }
 
-  _setFn(fn) {
+  update(fn) {
     const currentState = this.data.toJS();
     const newFields = fn(currentState);
     if (newFields === null || newFields === undefined) {
@@ -30,17 +31,8 @@ export default class Podda {
     }
 
     Object.keys(newFields).forEach((key) => {
-      this._setItem(key, newFields[key]);
+      this.set(key, newFields[key]);
     });
-  }
-
-  _setItem(key, value) {
-    this.data = this.data.set(key, Immutable.fromJS(value));
-    this.callbacks.forEach((cb) => {
-      cb(this.getAll());
-    });
-
-    this.fire(key, value);
   }
 
   get(key) {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default class Podda {
     }
 
     Object.keys(newFields).forEach((key) => {
-      this.set(key, newFields[key]);
+      this._setItem(key, newFields[key]);
     });
   }
 

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -22,6 +22,41 @@ describe('Podda', () => {
       expect(store.get('abc')).to.be.equal('ppc');
     });
 
+    it('should support a function for set', () => {
+      const store = new Podda({
+        abc: 10,
+        bbc: 20,
+      });
+
+      store.set((state) => {
+        expect(state).to.deep.equal({ abc: 10, bbc: 20 });
+        // this is not going to add to the store.
+        state.someItem = 1000; // eslint-disable-line
+
+        return { bbc: 50, cnn: 100 };
+      });
+
+      expect(store.getAll()).to.deep.equal({
+        abc: 10,
+        bbc: 50,
+        cnn: 100,
+      });
+    });
+
+    it('should throw an error if set function returns nothing', () => {
+      const store = new Podda();
+      const run1 = () => {
+        store.set(() => null);
+      };
+
+      const run2 = () => {
+        store.set(() => {});
+      };
+
+      expect(run1).to.throw(/an object with updated values/);
+      expect(run2).to.throw(/an object with updated values/);
+    });
+
     it('should support getting all the values', () => {
       const store = new Podda();
       store.set('abc', 'kkr');

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -22,13 +22,13 @@ describe('Podda', () => {
       expect(store.get('abc')).to.be.equal('ppc');
     });
 
-    it('should support a function for set', () => {
+    it('should support to update with a function', () => {
       const store = new Podda({
         abc: 10,
         bbc: 20,
       });
 
-      store.set((state) => {
+      store.update((state) => {
         expect(state).to.deep.equal({ abc: 10, bbc: 20 });
         // this is not going to add to the store.
         state.someItem = 1000; // eslint-disable-line
@@ -43,14 +43,14 @@ describe('Podda', () => {
       });
     });
 
-    it('should throw an error if set function returns nothing', () => {
+    it('should throw an error if update function returns nothing', () => {
       const store = new Podda();
       const run1 = () => {
-        store.set(() => null);
+        store.update(() => null);
       };
 
       const run2 = () => {
-        store.set(() => {});
+        store.update(() => {});
       };
 
       expect(run1).to.throw(/an object with updated values/);


### PR DESCRIPTION
Here's an example way to do it.

```js
store.update(function(state) {
  return {
    newField: 10,
    existingField: !Boolean(existingField)
  };
});
```