### PR TITLE
Add a way to register a new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ store.fire('name', 'Matt'); // logs => Name is: Matt
 console.log(store.get('name')) // logs => Arunoda
 ```
 
+### registerAPI
+
+With this, you'll be able to add new features to the store.
+For an example, let's say we are using toggle functionality in our store a lot. So, we can add an API for that like this:
+
+```js
+store.registerAPI('toggle', (store, key) => {
+  store.set(key, !store.get(key));
+  return store.get(key);
+});
+
+// Then we can use it like this:
+console.log('Toggled value for lights is:', store.toggle('lights'));
+```
+
 ## Using with React
 
 In order to use this with React, you need to get help from a data container. [React Komposer](https://github.com/arunoda/react-komposer) is an ideal tool for that.

--- a/src/index.js
+++ b/src/index.js
@@ -91,4 +91,14 @@ export default class Podda {
 
     return this.watch(key, callbackAndCheck);
   }
+
+  registerAPI(method, fn) {
+    if (this[method]) {
+      throw new Error(`Cannot add an API for the existing API: "${method}".`);
+    }
+
+    this[method] = (...args) => {
+      return fn(this, ...args);
+    };
+  }
 }

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -202,4 +202,25 @@ describe('Podda', () => {
       store.set('kkr', 30);
     });
   });
+
+  describe('registerAPI', () => {
+    it('should add new APIs to the store', () => {
+      const store = new Podda({ lights: false });
+      store.registerAPI('toggle', (s, key) => {
+        s.set(key, !store.get(key));
+        return s.get(key);
+      });
+
+      expect(store.toggle('lights')).to.be.equal(true);
+    });
+
+    it('should not override existing APIs', () => {
+      const store = new Podda({ lights: false });
+      const run = () => {
+        store.registerAPI('set', () => null);
+      };
+
+      expect(run).to.throw(/Cannot add an API for the existing API: "set"/);
+    });
+  });
 });


### PR DESCRIPTION
With this, you'll be able to add new features to the store.
For an example, let's say we are using toggle functionality in our store a lot. So, we can add an API for that like this:

```js
store.registerAPI('toggle', (store, key) => {
  store.set(key, !store.get(key));
  return store.get(key);
});

// Then we can use it like this:
console.log('Toggled value for lights is:', store.toggle('lights'));
```
