### PR TITLE
Allow this library to work with Node 8 / NPM 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "npm": "^3.0.0"
+    "npm": ">=3.0.0"
   }
 }


### PR DESCRIPTION
Currently installing this with NPM 5 fails with an 'Unsupported engine' error.